### PR TITLE
Remove extra_header field for releases

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -195,7 +195,6 @@ pub fn release_from_git(repo: &Repository, tag_oid: &git2::Oid) -> Result<Releas
         author,
         author_timestamp,
         author_timestamp_offset,
-        extra_headers: Vec::new(), // FIXME: does not seem to be exposed by git2
         message: tag.message_bytes().map(Into::into),
     })
 }

--- a/src/release.rs
+++ b/src/release.rs
@@ -17,7 +17,6 @@ pub struct Release {
     pub author: Option<Bytestring>,
     pub author_timestamp: Option<i64>,
     pub author_timestamp_offset: Option<Bytestring>,
-    pub extra_headers: Vec<(Bytestring, Bytestring)>,
     pub message: Option<Bytestring>,
 }
 
@@ -42,7 +41,6 @@ pub fn rel_manifest(rev: &Release) -> Vec<u8> {
         author,
         author_timestamp,
         author_timestamp_offset,
-        extra_headers,
         message,
     } = rev;
     let mut writer = HeaderWriter::default();
@@ -69,10 +67,6 @@ pub fn rel_manifest(rev: &Release) -> Vec<u8> {
             ),
         (None, None, None) => (),
         _ => (), // unspecified, see https://github.com/swhid/specification/issues/62
-    }
-
-    for (key, value) in extra_headers {
-        writer.push(key, value)
     }
 
     writer.build(message.as_ref())

--- a/tests/git.rs
+++ b/tests/git.rs
@@ -199,7 +199,6 @@ fn test_release_swhid() {
             author: Some(bs("Test User <test@example.com>")),
             author_timestamp: Some(1763027354),
             author_timestamp_offset: Some(bs("+0100")),
-            extra_headers: Vec::new(),
             message: Some(bs("Test tag")),
         }
     );

--- a/tests/release.rs
+++ b/tests/release.rs
@@ -18,7 +18,6 @@ fn simple_rel_hash() {
         author: Some(bs("Test User <test@example.com>")),
         author_timestamp: Some(1763027354),
         author_timestamp_offset: Some(bs("+0100")),
-        extra_headers: Vec::new(),
         message: Some(bs("Test tag")),
     };
 


### PR DESCRIPTION
They are not allowed by the SWHID spec.

Alternatively, I have an implementation for a parser from git if we want to support them despite the spec.

Resolves https://github.com/swhid/swhid-rs/issues/17