### PR TITLE
feat: add gitoxide backend as MIT/Apache-2.0 alternative to libgit2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +28,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anes"
@@ -53,7 +77,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,8 +88,23 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_fs"
@@ -110,6 +149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -118,6 +158,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cast"
@@ -211,10 +257,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "criterion"
@@ -250,6 +323,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -327,10 +409,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -339,7 +433,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -349,10 +453,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -411,6 +548,578 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01237e8d3d78581f71642be8b0c2ae8c0b2b5c251c9c5d9ebbea3c1ea280dce8"
+dependencies = [
+ "gix-actor",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-index",
+ "gix-lock",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "once_cell",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.35.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987a51a7e66db6ef4dc030418eb2a42af6b913a79edd8670766122d8af3ba59e"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c356b3825677cb6ff579551bb8311a81821e184453cbd105e2fc5311b288eeb"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46f9c425730a654835351e6da8c3c69ba1804f8b8d4e96d027254151138d5c64"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05050fd6caa6c731fe3bd7f9485b3b520be062d3d139cb2626e052d6c127951"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-hash",
+ "memmap2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f3c8f357ae049bfb77493c2ec9010f58cfc924ae485e1116c3718fc0f0d881"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "661245d045aa7c16ba4244daaabd823c562c3e45f1f25b816be2c57ee09f2171"
+dependencies = [
+ "bstr",
+ "itoa",
+ "jiff",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9b43e95fe352da82a969f0c84ff860c2de3e724d93f6681fedbcd6c917f252"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-object",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dccfe3e25b4ea46083916c56db3ba9d1e6ef6dce54da485f0463f9fc0fe1837c"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f4399af6ec4fd9db84dd4cf9656c5c785ab492ab40a7c27ea92b4241923fed"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "flate2",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a0637149b4ef24d3ea55f81f77231401c8463fae6da27331c987957eb597c7"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90181472925b587f6079698f79065ff64786e6d6c14089517a1972bca99fb6e9"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d4900562c662852a6b42e2ef03442eccebf24f047d8eab4f23bc12ef0d785d8"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b5cb3c308b4144f2612ff64e32130e641279fcf1a84d8d40dad843b4f64904"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.14.5",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38e919efd59cb8275d23ad2394b2ab9d002007b27620e145d866d546403b665"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.14.5",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.49.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d957ca3640c555d48bb27f8278c67169fa1380ed94f6452c5590742524c40fbb"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.69.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868f703905fdbcfc1bd750942f82419903ecb7039f5288adb5206d6de405e0c9"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d49c55d69c8449f2a0a5a77eb9cbacfebb6b0e2f1215f0fc23a4cb60528a450"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64286a8b5148e76ab80932e72762dd27ccf6169dd7a134b027c8a262a8262fcf"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c17d78bb0414f8d60b5f952196dc2e47ec320dca885de9128ecdb4a0e38401"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b7985657029684d759f656b09abc3e2c73085596d5cdb494428823970a7762"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445ed14e3db78e8e79980085e3723df94e1c8163b3ae5bc8ed6a8fe6cf983b42"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78d0b8e5cbd1c329e25383e088cb8f17439414021a643b30afa5146b71e3c65d"
+dependencies = [
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc756b73225bf005ddeb871d1ca7b3c33e2417d0d53e56effa5a36765b52b28"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dabbc78c759ecc006b970339394951b2c8e1e38a37b072c105b80b84c308fd"
+dependencies = [
+ "bitflags",
+ "gix-path",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9a6f6e34d6ede08f522d89e5c7990b4f60524b8ae6ebf8e850963828119ad4"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c750e8c008453a2dba67a2b0d928b7716e05da31173a3f5e351d5457ad4470aa"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+
+[[package]]
+name = "gix-transport"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfe22ba26d4b65c17879f12b9882eafe65d3c8611c933b272fce2c10f546f59"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8648172f85aca3d6e919c06504b7ac26baef54e04c55eb0100fa588c102cc33"
+dependencies = [
+ "bitflags",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42a1ad0b04a5718b5cb233e6888e52a9b627846296161d81dcc5eb9203ec84b8"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+dependencies = [
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+dependencies = [
+ "bstr",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +1152,46 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -589,7 +1338,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -612,6 +1361,47 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -654,6 +1444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "libssh2-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,16 +1494,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "num-traits"
@@ -749,6 +1590,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.18",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +1623,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -786,6 +1656,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -834,6 +1719,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "29.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc"
+dependencies = [
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,6 +1761,24 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -907,7 +1820,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -924,6 +1837,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -969,6 +1888,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha1collisiondetection"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,10 +1919,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "smallvec"
@@ -1010,12 +1962,13 @@ dependencies = [
  "clap",
  "criterion",
  "git2",
+ "gix",
  "hex",
  "percent-encoding",
  "serde",
  "sha1collisiondetection",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1050,7 +2003,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1065,7 +2018,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1073,6 +2035,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1100,16 +2073,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "url"
@@ -1227,7 +2239,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1238,11 +2250,93 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1353,6 +2447,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["encoding", "data-structures", "parsing"]
 default = []
 serde = ["dep:serde"]
 git = ["dep:git2"]
+gitoxide = ["dep:gix"]
 
 [dependencies]
 hex = "0.4"
@@ -21,6 +22,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 clap = { version = "4", features = ["derive"] }
 sha1collisiondetection = { version = "0.3" }
 git2 = { version = "0.20", optional = true }
+gix = { version = "0.72", optional = true, default-features = false, features = ["max-performance-safe", "index"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This implementation is **fully compliant** with SWHID v1.2 and provides:
 - All SWHID v1.2 object types: contents (`cnt`), directories (`dir`), revisions (`rev`), releases (`rel`), snapshots (`snp`)
 - Qualified identifiers (origin, visit, anchor, path, lines, bytes)
 - SWHID v1.2 compliant hash computation for **content** and **directory** objects
-- Optional VCS integration: computing `rev`, `rel`, `snp` SWHIDs from Git (requires `git` feature)
+- Optional VCS integration: computing `rev`, `rel`, `snp` SWHIDs from Git (requires `git` or `gitoxide` feature)
 
 ## Installing the CLI
 
-- **Rust:** `cargo install swhid` (add `--features git` for VCS commands).
+- **Rust:** `cargo install swhid` (add `--features git` for VCS via libgit2, or `--features gitoxide` for VCS via gitoxide).
 - **Binaries:** [Releases](https://github.com/swhid/swhid-rs/releases) or [Actions](https://github.com/swhid/swhid-rs/actions/workflows/release-binaries.yml). Download for your OS/arch, extract, run (e.g. `./swhid --help`).
 - **More:** [User guide](docs/user-guide.md) for all install options, library usage, examples, and CLI reference.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -16,7 +16,14 @@ Parsing: `Swhid::from_str` or `"swh:1:cnt:...".parse::<Swhid>()`. Display uses l
 
 ### Git integration
 
-With the `git` feature, use `swhid::git` to compute revision, release, and snapshot SWHIDs from a Git repository: `revision_swhid`, `release_swhid`, `snapshot_swhid`, etc.
+Two backend options are available for computing revision, release, and snapshot SWHIDs from Git repositories:
+
+- **`git` feature** — uses libgit2 (via the `git2` crate).
+- **`gitoxide` feature** — uses gitoxide (via the `gix` crate).
+
+Both produce identical SWHIDs.
+
+With the `git` feature, use `swhid::git`. With the `gitoxide` feature, use `swhid::git_gix`. Both modules expose the same functions: `revision_swhid`, `release_swhid`, `snapshot_swhid`, `open_repo`, `get_head_commit`, `get_tags`.
 
 ## CLI
 
@@ -24,7 +31,8 @@ With the `git` feature, use `swhid::git` to compute revision, release, and snaps
 
 1. **From crates.io**  
    `cargo install swhid`  
-   With Git support: `cargo install swhid --features git`
+   With Git support (libgit2): `cargo install swhid --features git`  
+   With Git support (gitoxide): `cargo install swhid --features gitoxide`
 
 2. **From source**  
    `cargo run --bin swhid -- [args...]` or `cargo build --release && ./target/release/swhid [args...]`
@@ -89,7 +97,7 @@ println!("Qualified SWHID: {}", qualified);
 # Ok::<_, Box<dyn std::error::Error>>(())
 ```
 
-### VCS integration (Git feature)
+### VCS integration (git feature — libgit2)
 
 ```rust,no_run
 use std::path::PathBuf;
@@ -104,6 +112,24 @@ use std::path::PathBuf;
     let tag_oid = repo.refname_to_id("refs/tags/v1.0.0")?;
     let release_swhid = git::release_swhid(&repo, &tag_oid)?;
     let snapshot_swhid = git::snapshot_swhid(&repo)?;
+}
+
+# Ok::<_, Box<dyn std::error::Error>>(())
+```
+
+### VCS integration (gitoxide feature)
+
+```rust,no_run
+use std::path::PathBuf;
+
+#[cfg(feature = "gitoxide")]
+{
+    use swhid::git_gix;
+
+    let repo = git_gix::open_repo(&PathBuf::from("/path/to/git/repo"))?;
+    let head_commit = git_gix::get_head_commit(&repo)?;
+    let revision_swhid = git_gix::revision_swhid(&repo, &head_commit, &mut std::collections::HashMap::new())?;
+    let snapshot_swhid = git_gix::snapshot_swhid(&repo)?;
 }
 
 # Ok::<_, Box<dyn std::error::Error>>(())
@@ -124,7 +150,7 @@ swhid dir --exclude .tmp --exclude .log /path/to/project
 swhid parse 'swh:1:cnt:e69de29bb2d1d6434b8b29ae775ad8c2e48c5391'
 swhid verify README.md 'swh:1:cnt:...'
 
-# Git (requires --features git)
+# Git (requires --features git or --features gitoxide)
 swhid git revision /path/to/git/repo [COMMIT]
 swhid git release /path/to/git/repo v1.0.0
 swhid git snapshot /path/to/git/repo
@@ -133,7 +159,10 @@ swhid git tags /path/to/git/repo
 
 ## Cargo features
 
-| Feature | Description |
-|---------|-------------|
-| `git` | VCS integration for revision, release, and snapshot SWHID computation |
-| `serde` | `Serialize`/`Deserialize` for public types |
+| Feature | Backend | Description |
+|---------|---------|-------------|
+| `git` | libgit2 | VCS integration for revision, release, and snapshot SWHIDs |
+| `gitoxide` | gix | Same VCS integration, pure-Rust backend |
+| `serde` | — | `Serialize`/`Deserialize` for public types |
+
+Both `git` and `gitoxide` provide the same SWHID computation for revision, release, and snapshot objects. They differ only in the underlying Git library. When both features are enabled, `git` (libgit2) takes priority in the CLI.

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -163,10 +163,9 @@ fn read_dir(
     opts: &DirectoryBuildOptions,
 ) -> Result<Vec<Entry>, crate::error::SwhidError> {
     use crate::permissions::{
-        AutoPermissionsSource, FilesystemPermissionsSource, ManifestPermissionsSource,
+        AutoPermissionsSource, FilesystemPermissionsSource, GitIndexPermissionsSource,
+        GitTreePermissionsSource, ManifestPermissionsSource,
     };
-    #[cfg(feature = "git")]
-    use crate::permissions::{GitIndexPermissionsSource, GitTreePermissionsSource};
 
     // Create permission source based on options
     let permission_source: Box<dyn PermissionsSource> = match opts.permissions_source {
@@ -175,6 +174,16 @@ fn read_dir(
         #[cfg(feature = "git")]
         PermissionsSourceKind::GitIndex => {
             let repo = git2::Repository::open(root).map_err(|e| {
+                crate::error::SwhidError::Io(std::io::Error::other(format!(
+                    "Failed to open Git repository: {}",
+                    e
+                )))
+            })?;
+            Box::new(GitIndexPermissionsSource::new(repo, root.to_path_buf()))
+        }
+        #[cfg(all(feature = "gitoxide", not(feature = "git")))]
+        PermissionsSourceKind::GitIndex => {
+            let repo = gix::open(root).map_err(|e| {
                 crate::error::SwhidError::Io(std::io::Error::other(format!(
                     "Failed to open Git repository: {}",
                     e
@@ -192,6 +201,16 @@ fn read_dir(
             })?;
             Box::new(GitTreePermissionsSource::new(repo, root.to_path_buf()))
         }
+        #[cfg(all(feature = "gitoxide", not(feature = "git")))]
+        PermissionsSourceKind::GitTree => {
+            let repo = gix::open(root).map_err(|e| {
+                crate::error::SwhidError::Io(std::io::Error::other(format!(
+                    "Failed to open Git repository: {}",
+                    e
+                )))
+            })?;
+            Box::new(GitTreePermissionsSource::new(repo, root.to_path_buf()))
+        }
         PermissionsSourceKind::Manifest => {
             let manifest_path = opts.permissions_manifest_path.as_ref().ok_or_else(|| {
                 crate::error::SwhidError::InvalidFormat(
@@ -200,10 +219,10 @@ fn read_dir(
             })?;
             Box::new(ManifestPermissionsSource::load(manifest_path)?)
         }
-        #[cfg(not(feature = "git"))]
+        #[cfg(not(any(feature = "git", feature = "gitoxide")))]
         PermissionsSourceKind::GitIndex | PermissionsSourceKind::GitTree => {
             return Err(crate::error::SwhidError::InvalidFormat(
-                "Git permission sources require the 'git' feature".to_string(),
+                "Git permission sources require the 'git' or 'gitoxide' feature".to_string(),
             ));
         }
         PermissionsSourceKind::Heuristic => {

--- a/src/git.rs
+++ b/src/git.rs
@@ -82,15 +82,6 @@ fn directory_swhid_from_tree(
 }
 
 fn parse_signature(sig: Signature) -> (Bytestring, i64, Bytestring) {
-    let name = sig.name_bytes();
-    let email = sig.email_bytes();
-
-    let mut full_name = Vec::with_capacity(name.len() + email.len() + 3);
-    full_name.extend_from_slice(name);
-    full_name.extend_from_slice(b" <");
-    full_name.extend_from_slice(email);
-    full_name.push(b'>');
-
     let when = sig.when();
     let sign = when.sign();
     let offset_minutes = when.offset_minutes().abs();
@@ -98,7 +89,7 @@ fn parse_signature(sig: Signature) -> (Bytestring, i64, Bytestring) {
     let offset_minutes = offset_minutes % 60;
     let offset = format!("{sign}{offset_hours:02}{offset_minutes:02}");
 
-    (full_name.into(), when.seconds(), offset.into_bytes().into())
+    crate::utils::build_signature(sig.name_bytes(), sig.email_bytes(), when.seconds(), &offset)
 }
 
 /// Returns key-value pairs and the message

--- a/src/git_gix.rs
+++ b/src/git_gix.rs
@@ -1,0 +1,443 @@
+//! SWHID v1.2 VCS integration for Git repositories (gitoxide backend)
+//!
+//! This module provides the same functionality as the `git` module but uses
+//! gitoxide (gix) instead of libgit2. The gitoxide crate is licensed MIT/Apache-2.0,
+//! making it compatible with all permissive license requirements.
+//!
+//! Enable with `--features gitoxide`. Provides:
+//! - Revision SWHIDs (commits) - `swh:1:rev:<digest>`
+//! - Release SWHIDs (tags) - `swh:1:rel:<digest>`
+//! - Snapshot SWHIDs (repository state) - `swh:1:snp:<digest>`
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::path::Path;
+
+use gix::object::Kind;
+use gix::ObjectId;
+
+use crate::directory::{dir_manifest, Entry as DirEntry};
+use crate::error::SwhidError;
+use crate::hash::{hash_content, hash_swhid_object};
+use crate::release::Release;
+use crate::revision::Revision;
+use crate::snapshot::{Branch, BranchTarget, Snapshot};
+use crate::Bytestring;
+use crate::Swhid;
+
+fn io_error(msg: String) -> SwhidError {
+    SwhidError::Io(std::io::Error::other(msg))
+}
+
+/// Convert a BStr/BString to Box<[u8]> (our Bytestring type).
+fn bstr_to_box(b: &[u8]) -> Box<[u8]> {
+    b.to_vec().into_boxed_slice()
+}
+
+/// Content SWHID digest (20 bytes) from a Git blob OID.
+fn content_swhid_from_blob(
+    repo: &gix::Repository,
+    blob_oid: ObjectId,
+) -> Result<[u8; 20], SwhidError> {
+    let blob = repo
+        .find_blob(blob_oid)
+        .map_err(|e| io_error(format!("Failed to find blob {blob_oid}: {e}")))?;
+    Ok(hash_content(blob.data.as_ref()))
+}
+
+/// Directory SWHID digest (20 bytes) from a Git tree OID.
+fn directory_swhid_from_tree(
+    repo: &gix::Repository,
+    tree_oid: ObjectId,
+    cache: &mut HashMap<ObjectId, [u8; 20]>,
+) -> Result<[u8; 20], SwhidError> {
+    let tree = repo
+        .find_tree(tree_oid)
+        .map_err(|e| io_error(format!("Failed to find tree {tree_oid}: {e}")))?;
+    let mut entries: Vec<DirEntry> = Vec::new();
+    for entry_ref in tree.iter() {
+        let entry = entry_ref.map_err(|e| io_error(format!("Failed to read tree entry: {e}")))?;
+        let name = bstr_to_box(entry.filename());
+        // Convert mode to u32 via the octal string representation
+        let mode_str = entry.mode().as_str();
+        let mode = u32::from_str_radix(mode_str, 8).unwrap_or(0o100644);
+        let oid = entry.oid();
+        let entry_kind = entry.mode().kind();
+
+        let id = match entry_kind {
+            gix::object::tree::EntryKind::Blob | gix::object::tree::EntryKind::BlobExecutable => {
+                match cache.entry(oid.into()) {
+                    Entry::Occupied(e) => *e.get(),
+                    Entry::Vacant(e) => *e.insert(content_swhid_from_blob(repo, oid.into())?),
+                }
+            }
+            gix::object::tree::EntryKind::Tree => match cache.entry(oid.into()) {
+                Entry::Occupied(e) => *e.get(),
+                Entry::Vacant(_) => {
+                    let swhid = directory_swhid_from_tree(repo, oid.into(), cache)?;
+                    cache.insert(oid.into(), swhid);
+                    swhid
+                }
+            },
+            gix::object::tree::EntryKind::Link => {
+                // Symlinks are treated as blobs for SWHID purposes
+                match cache.entry(oid.into()) {
+                    Entry::Occupied(e) => *e.get(),
+                    Entry::Vacant(e) => *e.insert(content_swhid_from_blob(repo, oid.into())?),
+                }
+            }
+            _ => {
+                return Err(io_error(format!(
+                    "Tree entry {:?} has unsupported type",
+                    String::from_utf8_lossy(entry.filename())
+                )));
+            }
+        };
+        entries.push(DirEntry::new(name, mode, id));
+    }
+    let manifest =
+        dir_manifest(entries).map_err(|e| io_error(format!("Directory manifest: {e}")))?;
+    Ok(hash_swhid_object("tree", &manifest))
+}
+
+/// Parse a gitoxide actor signature into (fullname, timestamp, offset).
+fn parse_gix_signature(sig: gix::actor::SignatureRef<'_>) -> (Bytestring, i64, Bytestring) {
+    // sig.time is a raw string like "1763027354 +0100"
+    let time_str = sig.time.trim();
+    let (timestamp, offset) = if let Some(space_pos) = time_str.rfind(' ') {
+        let ts_str = &time_str[..space_pos];
+        let tz_str = &time_str[space_pos + 1..];
+        let ts = ts_str.parse::<i64>().unwrap_or(0);
+        (ts, tz_str.to_string())
+    } else {
+        (time_str.parse::<i64>().unwrap_or(0), "+0000".to_string())
+    };
+
+    crate::utils::build_signature(sig.name.as_ref(), sig.email.as_ref(), timestamp, &offset)
+}
+
+/// Returns key-value pairs from a raw commit/tag header
+fn parse_header(mut manifest: &[u8]) -> Result<Vec<(&[u8], Bytestring)>, SwhidError> {
+    let mut headers = Vec::new();
+    while !manifest.is_empty() {
+        let Some(newline_position) = manifest.iter().position(|&byte| byte == b'\n') else {
+            return Err(io_error("Header line is missing a line end".to_owned()));
+        };
+        let first_line = &manifest[..newline_position];
+        manifest = &manifest[newline_position + 1..];
+
+        let Some(delimiter_position) = first_line.iter().position(|&byte| byte == b' ') else {
+            return Err(io_error("Header line is missing a value".to_owned()));
+        };
+        let key = &first_line[..delimiter_position];
+        if key.is_empty() {
+            return Err(io_error("Empty key".to_owned()));
+        };
+        let mut value = first_line[delimiter_position + 1..].to_vec();
+
+        while let Some(newline_position) = manifest.iter().position(|&byte| byte == b'\n') {
+            let line = &manifest[..newline_position];
+            match line.split_first() {
+                None => {
+                    return Err(io_error("Empty line".to_owned()));
+                }
+                Some((b' ', value_line)) => {
+                    value.push(b'\n');
+                    value.extend_from_slice(value_line);
+                }
+                Some(_) => {
+                    break;
+                }
+            }
+            manifest = &manifest[newline_position + 1..];
+        }
+        headers.push((key, value.into_boxed_slice()));
+    }
+    Ok(headers)
+}
+
+/// Compute a SWHID v1.2 revision identifier from a Git commit
+pub fn revision_swhid(
+    repo: &gix::Repository,
+    commit_oid: &ObjectId,
+    cache: &mut HashMap<ObjectId, [u8; 20]>,
+) -> Result<Swhid, SwhidError> {
+    revision_from_git(repo, commit_oid, cache).map(|rev| rev.swhid())
+}
+
+#[doc(hidden)]
+pub fn revision_from_git(
+    repo: &gix::Repository,
+    commit_oid: &ObjectId,
+    cache: &mut HashMap<ObjectId, [u8; 20]>,
+) -> Result<Revision, SwhidError> {
+    let commit_obj = repo
+        .find_object(*commit_oid)
+        .map_err(|e| io_error(format!("Failed to find commit: {e}")))?;
+    let commit = commit_obj
+        .try_into_commit()
+        .map_err(|e| io_error(format!("Object is not a commit: {e}")))?;
+    let commit_ref = commit
+        .decode()
+        .map_err(|e| io_error(format!("Failed to decode commit: {e}")))?;
+
+    let tree_oid = commit_ref.tree();
+    let directory = directory_swhid_from_tree(repo, tree_oid.into(), cache)?;
+
+    let parents: Vec<[u8; 20]> = commit_ref
+        .parents()
+        .map(|parent_oid| {
+            let parent_id: ObjectId = parent_oid.into();
+            match cache.entry(parent_id) {
+                Entry::Occupied(e) => Ok(*e.get()),
+                Entry::Vacant(_) => {
+                    let swhid = *revision_swhid(repo, &parent_id, cache)?.digest_bytes();
+                    cache.insert(parent_id, swhid);
+                    Ok(swhid)
+                }
+            }
+        })
+        .collect::<Result<Vec<_>, SwhidError>>()?;
+
+    let (author, author_timestamp, author_timestamp_offset) =
+        parse_gix_signature(commit_ref.author);
+    let (committer, committer_timestamp, committer_timestamp_offset) =
+        parse_gix_signature(commit_ref.committer);
+
+    // Parse extra headers from raw commit data
+    let raw_data: &[u8] = commit.data.as_ref();
+    // Find the header section (everything before the first \n\n)
+    let header_end = raw_data
+        .windows(2)
+        .position(|w| w == b"\n\n")
+        .unwrap_or(raw_data.len());
+    let raw_header = &raw_data[..header_end + 1]; // include trailing \n
+
+    let headers = parse_header(raw_header)?;
+    let extra_headers = headers
+        .into_iter()
+        .filter(|(key, _value)| !matches!(*key, b"tree" | b"parent" | b"author" | b"committer"))
+        .map(|(key, value)| (key.into(), value))
+        .collect();
+
+    let message_bytes: &[u8] = commit_ref.message.as_ref();
+    Ok(Revision {
+        directory,
+        parents,
+        author,
+        author_timestamp,
+        author_timestamp_offset,
+        committer,
+        committer_timestamp,
+        committer_timestamp_offset,
+        extra_headers,
+        message: Some(message_bytes.to_vec().into_boxed_slice()),
+    })
+}
+
+/// Compute a SWHID v1.2 release identifier from a Git tag
+pub fn release_swhid(repo: &gix::Repository, tag_oid: &ObjectId) -> Result<Swhid, SwhidError> {
+    release_from_git(repo, tag_oid).map(|rel| rel.swhid())
+}
+
+#[doc(hidden)]
+pub fn release_from_git(repo: &gix::Repository, tag_oid: &ObjectId) -> Result<Release, SwhidError> {
+    let tag_obj = repo
+        .find_object(*tag_oid)
+        .map_err(|e| io_error(format!("Failed to find tag: {e}")))?;
+    let tag = tag_obj
+        .try_into_tag()
+        .map_err(|e| io_error(format!("Object is not a tag: {e}")))?;
+    let tag_ref = tag
+        .decode()
+        .map_err(|e| io_error(format!("Failed to decode tag: {e}")))?;
+
+    let target_oid: ObjectId = tag_ref.target().into();
+    let target_kind = tag_ref.target_kind;
+
+    use crate::release::ReleaseTargetType;
+
+    let object = match target_kind {
+        Kind::Commit => *revision_swhid(repo, &target_oid, &mut HashMap::new())?.digest_bytes(),
+        Kind::Tree => directory_swhid_from_tree(repo, target_oid, &mut HashMap::new())?,
+        Kind::Blob => content_swhid_from_blob(repo, target_oid)?,
+        Kind::Tag => *release_swhid(repo, &target_oid)?.digest_bytes(),
+    };
+
+    let object_type = match target_kind {
+        Kind::Commit => ReleaseTargetType::Revision,
+        Kind::Tree => ReleaseTargetType::Directory,
+        Kind::Blob => ReleaseTargetType::Content,
+        Kind::Tag => ReleaseTargetType::Release,
+    };
+
+    let (author, author_timestamp, author_timestamp_offset) = match tag_ref.tagger {
+        Some(tagger) => {
+            let (a, t, o) = parse_gix_signature(tagger);
+            (Some(a), Some(t), Some(o))
+        }
+        None => (None, None, None),
+    };
+
+    let tag_name: &[u8] = tag_ref.name.as_ref();
+    let tag_message: Option<Box<[u8]>> = if tag_ref.message.is_empty() {
+        None
+    } else {
+        let msg_bytes: &[u8] = tag_ref.message.as_ref();
+        Some(msg_bytes.to_vec().into_boxed_slice())
+    };
+
+    Ok(Release {
+        object,
+        object_type,
+        name: tag_name.to_vec().into_boxed_slice(),
+        author,
+        author_timestamp,
+        author_timestamp_offset,
+        extra_headers: Vec::new(),
+        message: tag_message,
+    })
+}
+
+/// Compute a SWHID v1.2 snapshot identifier from a Git repository
+pub fn snapshot_swhid(repo: &gix::Repository) -> Result<Swhid, SwhidError> {
+    snapshot_from_git(repo).map(|snp| snp.swhid())
+}
+
+#[doc(hidden)]
+pub fn snapshot_from_git(repo: &gix::Repository) -> Result<Snapshot, SwhidError> {
+    let references = repo
+        .references()
+        .map_err(|e| io_error(format!("Failed to list references: {e}")))?;
+
+    let all_refs = references
+        .all()
+        .map_err(|e| io_error(format!("Failed to iterate references: {e}")))?;
+
+    let mut cache = HashMap::new();
+    let mut branches: Vec<Branch> = Vec::new();
+
+    for reference in all_refs {
+        let reference =
+            reference.map_err(|e| io_error(format!("Failed to read reference: {e}")))?;
+        if let Some(branch) = reference_to_branch(repo, &reference, &mut cache)? {
+            branches.push(branch);
+        }
+    }
+
+    // Add HEAD as alias
+    let head = repo
+        .head_ref()
+        .map_err(|e| io_error(format!("Failed to get HEAD: {e}")))?;
+    if let Some(head_ref) = head {
+        let target_name: &[u8] = head_ref.name().as_bstr().as_ref();
+        branches.push(Branch {
+            name: (*b"HEAD").into(),
+            target: BranchTarget::Alias(Some(target_name.to_vec().into_boxed_slice())),
+        });
+    }
+
+    Snapshot::new(branches).map_err(|e| io_error(format!("Invalid snapshot: {e}")))
+}
+
+fn reference_to_branch(
+    repo: &gix::Repository,
+    reference: &gix::Reference<'_>,
+    cache: &mut HashMap<ObjectId, [u8; 20]>,
+) -> Result<Option<Branch>, SwhidError> {
+    let name_bytes: &[u8] = reference.name().as_bstr().as_ref();
+    // Only process branches and tags
+    if !name_bytes.starts_with(b"refs/heads/") && !name_bytes.starts_with(b"refs/tags/") {
+        return Ok(None);
+    }
+
+    let name: Box<[u8]> = name_bytes.to_vec().into_boxed_slice();
+
+    // Check if this is a direct (peeled) or symbolic reference
+    match reference.try_id() {
+        Some(oid) => {
+            let target_id: ObjectId = oid.into();
+            let obj = match repo.find_object(target_id) {
+                Ok(obj) => obj,
+                Err(_) => {
+                    // Dangling branch
+                    return Ok(Some(Branch {
+                        name,
+                        target: BranchTarget::Revision(None),
+                    }));
+                }
+            };
+            let target = match obj.kind {
+                Kind::Commit => {
+                    let digest = *revision_swhid(repo, &target_id, cache)?.digest_bytes();
+                    BranchTarget::Revision(Some(digest))
+                }
+                Kind::Tree => {
+                    let digest = directory_swhid_from_tree(repo, target_id, cache)?;
+                    BranchTarget::Directory(Some(digest))
+                }
+                Kind::Blob => {
+                    let digest = match cache.entry(target_id) {
+                        Entry::Occupied(e) => *e.get(),
+                        Entry::Vacant(e) => *e.insert(content_swhid_from_blob(repo, target_id)?),
+                    };
+                    BranchTarget::Content(Some(digest))
+                }
+                Kind::Tag => {
+                    let digest = *release_swhid(repo, &target_id)?.digest_bytes();
+                    BranchTarget::Release(Some(digest))
+                }
+            };
+            Ok(Some(Branch { name, target }))
+        }
+        None => {
+            // Symbolic reference
+            if let Some(target_name) = reference.name().as_bstr().strip_prefix(b"ref: ") {
+                Ok(Some(Branch {
+                    name,
+                    target: BranchTarget::Alias(Some(target_name.to_vec().into_boxed_slice())),
+                }))
+            } else {
+                // Try symbolic_target approach
+                Ok(Some(Branch {
+                    name,
+                    target: BranchTarget::Revision(None),
+                }))
+            }
+        }
+    }
+}
+
+/// Open a Git repository for SWHID v1.2 computation
+pub fn open_repo(path: &Path) -> Result<gix::Repository, SwhidError> {
+    gix::open(path).map_err(|e| io_error(format!("Failed to open repository: {e}")))
+}
+
+/// Get the HEAD commit OID of a Git repository
+pub fn get_head_commit(repo: &gix::Repository) -> Result<ObjectId, SwhidError> {
+    let head = repo
+        .head_commit()
+        .map_err(|e| io_error(format!("Failed to get HEAD commit: {e}")))?;
+    Ok(head.id().into())
+}
+
+/// Get all annotated tag OIDs in a Git repository
+pub fn get_tags(repo: &gix::Repository) -> Result<Vec<ObjectId>, SwhidError> {
+    let references = repo
+        .references()
+        .map_err(|e| io_error(format!("Failed to list references: {e}")))?;
+
+    let tag_refs = references
+        .prefixed("refs/tags/")
+        .map_err(|e| io_error(format!("Failed to filter tags: {e}")))?;
+
+    let mut tags = Vec::new();
+    for reference in tag_refs {
+        let reference =
+            reference.map_err(|e| io_error(format!("Failed to read tag reference: {e}")))?;
+        if let Some(oid) = reference.try_id() {
+            tags.push(oid.into());
+        }
+    }
+    Ok(tags)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub mod directory;
 pub mod error;
 #[cfg(feature = "git")]
 pub mod git;
+#[cfg(feature = "gitoxide")]
+pub mod git_gix;
 pub mod hash;
 pub mod permissions;
 pub mod qualifier;
@@ -19,8 +21,8 @@ pub use core::{ObjectType, Swhid};
 pub use directory::{Directory, DiskDirectoryBuilder, Entry, WalkOptions};
 pub use directory::{DirectoryBuildOptions, ManifestEntry};
 pub use permissions::{
-    resolve_file_permissions, EntryExec, EntryPerms, PermissionPolicy, PermissionsSource,
-    PermissionsSourceKind,
+    resolve_file_permissions, EntryExec, EntryPerms, GitIndexPermissionsSource,
+    GitTreePermissionsSource, PermissionPolicy, PermissionsSource, PermissionsSourceKind,
 };
 pub use qualifier::{ByteRange, LineRange, QualifiedSwhid};
 pub use release::{Release, ReleaseTargetType};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,14 @@ use swhid::{
 };
 use swhid::{QualifiedSwhid, Swhid};
 
-#[cfg(feature = "git")]
+#[cfg(all(feature = "gitoxide", not(feature = "git")))]
+use gix;
+#[cfg(any(feature = "git", feature = "gitoxide"))]
 use std::collections::HashMap;
 #[cfg(feature = "git")]
 use swhid::git;
+#[cfg(all(feature = "gitoxide", not(feature = "git")))]
+use swhid::git_gix;
 
 /// Small CLI for the SWHID reference implementation
 #[derive(Parser, Debug)]
@@ -78,15 +82,15 @@ enum Command {
         #[arg(long, value_name = "PATH")]
         permissions_manifest: Option<PathBuf>,
     },
-    /// Git repository SWHID computation (requires --features git)
-    #[cfg(feature = "git")]
+    /// Git repository SWHID computation (requires --features git or --features gitoxide)
+    #[cfg(any(feature = "git", feature = "gitoxide"))]
     Git {
         #[command(subcommand)]
         cmd: GitCommand,
     },
 }
 
-#[cfg(feature = "git")]
+#[cfg(any(feature = "git", feature = "gitoxide"))]
 #[derive(Subcommand, Debug)]
 enum GitCommand {
     /// Compute revision SWHID for a commit
@@ -287,6 +291,45 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             GitCommand::Tags { repo } => {
                 let repo = git::open_repo(&repo)?;
                 let tags = git::get_tags(&repo)?;
+                for tag_oid in tags {
+                    println!("{tag_oid}");
+                }
+            }
+        },
+        #[cfg(all(feature = "gitoxide", not(feature = "git")))]
+        Command::Git { cmd } => match cmd {
+            GitCommand::Revision { repo, commit } => {
+                let repo = git_gix::open_repo(&repo)?;
+                let commit_oid = if let Some(commit_str) = commit {
+                    gix::ObjectId::from_hex(commit_str.as_bytes())
+                        .map_err(|e| format!("Invalid commit hash: {e}"))?
+                } else {
+                    git_gix::get_head_commit(&repo)?
+                };
+                let swhid = git_gix::revision_swhid(&repo, &commit_oid, &mut HashMap::new())?;
+                println!("{swhid}");
+            }
+            GitCommand::Release { repo, tag } => {
+                let repo = git_gix::open_repo(&repo)?;
+                let reference = repo
+                    .find_reference(&format!("refs/tags/{tag}"))
+                    .map_err(|e| format!("Tag not found: {e}"))?;
+                let tag_oid = reference
+                    .target()
+                    .try_id()
+                    .ok_or_else(|| "Tag is symbolic, not a direct reference".to_string())?
+                    .to_owned();
+                let swhid = git_gix::release_swhid(&repo, &tag_oid)?;
+                println!("{swhid}");
+            }
+            GitCommand::Snapshot { repo } => {
+                let repo = git_gix::open_repo(&repo)?;
+                let swhid = git_gix::snapshot_swhid(&repo)?;
+                println!("{swhid}");
+            }
+            GitCommand::Tags { repo } => {
+                let repo = git_gix::open_repo(&repo)?;
+                let tags = git_gix::get_tags(&repo)?;
                 for tag_oid in tags {
                     println!("{tag_oid}");
                 }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -127,7 +127,6 @@ pub fn resolve_file_permissions(
             path.display()
         ))),
         (EntryExec::Unknown, PermissionPolicy::BestEffort) => {
-            // Default to non-executable
             Ok(EntryPerms::File { executable: false })
         }
     }
@@ -159,33 +158,34 @@ impl PermissionsSource for FilesystemPermissionsSource {
         }
         #[cfg(not(unix))]
         {
-            let _ = path; // suppress unused warning
+            let _ = path;
             Ok(EntryExec::Unknown)
         }
     }
 }
 
-#[cfg(feature = "git")]
 /// Git index-based permission source.
 ///
 /// Reads executable bit from Git index entries.
 /// This is the recommended source for Windows when working with Git repositories.
-pub struct GitIndexPermissionsSource {
-    repo: git2::Repository,
+pub struct GitIndexPermissionsSource<R> {
+    repo: R,
     root: std::path::PathBuf,
 }
 
-#[cfg(feature = "git")]
-impl GitIndexPermissionsSource {
-    pub fn new(repo: git2::Repository, root: std::path::PathBuf) -> Self {
+impl<R> GitIndexPermissionsSource<R> {
+    pub fn new(repo: R, root: std::path::PathBuf) -> Self {
         Self { repo, root }
     }
 }
 
-#[cfg(feature = "git")]
-impl PermissionsSource for GitIndexPermissionsSource {
+/// Trait for querying executable status from a Git index.
+pub(crate) trait IndexExecutableQuery {
+    fn index_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError>;
+}
+
+impl<R: IndexExecutableQuery> PermissionsSource for GitIndexPermissionsSource<R> {
     fn executable_of(&self, path: &Path) -> Result<EntryExec, SwhidError> {
-        // Get relative path from repo root
         let rel_path = path.strip_prefix(&self.root).map_err(|_| {
             SwhidError::InvalidFormat(format!(
                 "Path {} is not under repository root {}",
@@ -193,51 +193,71 @@ impl PermissionsSource for GitIndexPermissionsSource {
                 self.root.display()
             ))
         })?;
-
-        // Convert to forward slashes for Git
         let git_path = rel_path.to_string_lossy().replace('\\', "/");
+        self.repo.index_is_executable(&git_path)
+    }
+}
 
-        let index = self.repo.index().map_err(|e| {
+#[cfg(feature = "git")]
+impl IndexExecutableQuery for git2::Repository {
+    fn index_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError> {
+        let index = self.index().map_err(|e| {
             SwhidError::Io(std::io::Error::other(format!(
                 "Failed to read Git index: {}",
                 e
             )))
         })?;
-
-        // Find entry in index
-        if let Some(entry) = index.get_path(Path::new(&git_path), 0) {
+        if let Some(entry) = index.get_path(Path::new(git_path), 0) {
             let mode = entry.mode;
-            // Git modes: 100644 = regular, 100755 = executable
             let executable = (mode & 0o111) != 0 || mode == 0o100755;
             Ok(EntryExec::Known(executable))
         } else {
-            // Not in index, return Unknown
             Ok(EntryExec::Unknown)
         }
     }
 }
 
-#[cfg(feature = "git")]
+#[cfg(feature = "gitoxide")]
+impl IndexExecutableQuery for gix::Repository {
+    fn index_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError> {
+        let index = self.index().map_err(|e| {
+            SwhidError::Io(std::io::Error::other(format!(
+                "Failed to read Git index: {}",
+                e
+            )))
+        })?;
+        if let Some(entry) = index.entry_by_path(git_path.as_bytes().into()) {
+            let mode = entry.mode.bits();
+            let executable = (mode & 0o111) != 0;
+            Ok(EntryExec::Known(executable))
+        } else {
+            Ok(EntryExec::Unknown)
+        }
+    }
+}
+
 /// Git tree-based permission source (HEAD).
 ///
 /// Reads executable bit from committed tree objects.
 /// This reflects the committed state rather than the working directory.
-pub struct GitTreePermissionsSource {
-    repo: git2::Repository,
+pub struct GitTreePermissionsSource<R> {
+    repo: R,
     root: std::path::PathBuf,
 }
 
-#[cfg(feature = "git")]
-impl GitTreePermissionsSource {
-    pub fn new(repo: git2::Repository, root: std::path::PathBuf) -> Self {
+impl<R> GitTreePermissionsSource<R> {
+    pub fn new(repo: R, root: std::path::PathBuf) -> Self {
         Self { repo, root }
     }
 }
 
-#[cfg(feature = "git")]
-impl PermissionsSource for GitTreePermissionsSource {
+/// Trait for querying executable status from a Git tree (HEAD).
+pub(crate) trait TreeExecutableQuery {
+    fn tree_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError>;
+}
+
+impl<R: TreeExecutableQuery> PermissionsSource for GitTreePermissionsSource<R> {
     fn executable_of(&self, path: &Path) -> Result<EntryExec, SwhidError> {
-        // Get relative path from repo root
         let rel_path = path.strip_prefix(&self.root).map_err(|_| {
             SwhidError::InvalidFormat(format!(
                 "Path {} is not under repository root {}",
@@ -245,12 +265,15 @@ impl PermissionsSource for GitTreePermissionsSource {
                 self.root.display()
             ))
         })?;
-
-        // Convert to forward slashes for Git
         let git_path = rel_path.to_string_lossy().replace('\\', "/");
+        self.repo.tree_is_executable(&git_path)
+    }
+}
 
-        // Get HEAD tree
-        let head = self.repo.head().map_err(|e| {
+#[cfg(feature = "git")]
+impl TreeExecutableQuery for git2::Repository {
+    fn tree_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError> {
+        let head = self.head().map_err(|e| {
             SwhidError::Io(std::io::Error::other(format!("Failed to get HEAD: {}", e)))
         })?;
         let commit = head.peel_to_commit().map_err(|e| {
@@ -263,7 +286,6 @@ impl PermissionsSource for GitTreePermissionsSource {
             SwhidError::Io(std::io::Error::other(format!("Failed to get tree: {}", e)))
         })?;
 
-        // Walk tree to find entry
         let path_parts: Vec<&str> = git_path.split('/').filter(|s| !s.is_empty()).collect();
         let mut current_tree = tree;
 
@@ -271,13 +293,11 @@ impl PermissionsSource for GitTreePermissionsSource {
             match current_tree.get_path(Path::new(part)) {
                 Ok(entry) => {
                     if i == path_parts.len() - 1 {
-                        // This is the file we're looking for
                         let mode = entry.filemode();
                         let executable = (mode & 0o111) != 0 || mode == 0o100755;
                         return Ok(EntryExec::Known(executable));
                     } else {
-                        // Navigate into subdirectory
-                        let obj = entry.to_object(&self.repo).map_err(|e| {
+                        let obj = entry.to_object(self).map_err(|e| {
                             SwhidError::Io(std::io::Error::other(format!(
                                 "Failed to get tree object: {}",
                                 e
@@ -293,7 +313,54 @@ impl PermissionsSource for GitTreePermissionsSource {
                     }
                 }
                 Err(_) => {
-                    // Not found in tree
+                    return Ok(EntryExec::Unknown);
+                }
+            }
+        }
+
+        Ok(EntryExec::Unknown)
+    }
+}
+
+#[cfg(feature = "gitoxide")]
+impl TreeExecutableQuery for gix::Repository {
+    fn tree_is_executable(&self, git_path: &str) -> Result<EntryExec, SwhidError> {
+        let head = self.head_commit().map_err(|e| {
+            SwhidError::Io(std::io::Error::other(format!("Failed to get HEAD: {}", e)))
+        })?;
+        let tree = head.tree().map_err(|e| {
+            SwhidError::Io(std::io::Error::other(format!("Failed to get tree: {}", e)))
+        })?;
+
+        let path_parts: Vec<&str> = git_path.split('/').filter(|s| !s.is_empty()).collect();
+        let mut current_tree = tree;
+
+        for (i, part) in path_parts.iter().enumerate() {
+            let found = current_tree.iter().find_map(|entry_result| {
+                let entry = entry_result.ok()?;
+                if entry.filename() == part.as_bytes() {
+                    Some((entry.mode(), entry.oid().to_owned()))
+                } else {
+                    None
+                }
+            });
+
+            match found {
+                Some((mode, oid)) => {
+                    if i == path_parts.len() - 1 {
+                        let mode_val = u32::from_str_radix(mode.as_str(), 8).unwrap_or(0o100644);
+                        let executable = (mode_val & 0o111) != 0;
+                        return Ok(EntryExec::Known(executable));
+                    } else {
+                        current_tree = self.find_tree(oid).map_err(|e| {
+                            SwhidError::Io(std::io::Error::other(format!(
+                                "Failed to get tree object: {}",
+                                e
+                            )))
+                        })?;
+                    }
+                }
+                None => {
                     return Ok(EntryExec::Unknown);
                 }
             }
@@ -349,14 +416,10 @@ impl ManifestPermissionsSource {
     /// executable = true
     /// ```
     pub fn parse(toml: &str) -> Result<Self, SwhidError> {
-        // Simple TOML parser for the specific format we need
-        // This avoids adding a TOML dependency for now
         let mut manifest = std::collections::HashMap::new();
 
-        // Split by [[file]] sections
         let sections: Vec<&str> = toml.split("[[file]]").collect();
         for section in sections.iter().skip(1) {
-            // Extract path and executable
             let mut path: Option<String> = None;
             let mut executable: Option<bool> = None;
 
@@ -376,7 +439,6 @@ impl ManifestPermissionsSource {
             }
 
             if let (Some(p), Some(exec)) = (path, executable) {
-                // Normalize path (forward slashes, reject .. and absolute)
                 let normalized = Self::normalize_path(&p)?;
                 manifest.insert(normalized, exec);
             }
@@ -386,7 +448,6 @@ impl ManifestPermissionsSource {
     }
 
     fn normalize_path(path: &str) -> Result<String, SwhidError> {
-        // Reject absolute paths
         if path.starts_with('/') || (cfg!(windows) && path.contains(':')) {
             return Err(SwhidError::InvalidFormat(format!(
                 "Manifest contains absolute path: {}",
@@ -394,7 +455,6 @@ impl ManifestPermissionsSource {
             )));
         }
 
-        // Reject .. segments
         if path.contains("..") {
             return Err(SwhidError::InvalidFormat(format!(
                 "Manifest contains '..' in path: {}",
@@ -402,14 +462,12 @@ impl ManifestPermissionsSource {
             )));
         }
 
-        // Normalize to forward slashes
         Ok(path.replace('\\', "/"))
     }
 }
 
 impl PermissionsSource for ManifestPermissionsSource {
     fn executable_of(&self, path: &Path) -> Result<EntryExec, SwhidError> {
-        // Normalize path for lookup
         let path_str = path.to_string_lossy().replace('\\', "/");
         if let Some(&executable) = self.manifest.get(&path_str) {
             Ok(EntryExec::Known(executable))
@@ -436,7 +494,6 @@ impl AutoPermissionsSource {
     /// If found and `git` feature is enabled, uses Git index source.
     /// Otherwise, falls back to filesystem source.
     pub fn new(_root: &Path) -> Result<Self, SwhidError> {
-        // Try to find Git repository
         #[cfg(feature = "git")]
         {
             let mut current = Some(_root);
@@ -452,16 +509,35 @@ impl AutoPermissionsSource {
                                 )),
                             });
                         }
-                        Err(_) => {
-                            // Continue searching
-                        }
+                        Err(_) => {}
                     }
                 }
                 current = path.parent();
             }
         }
 
-        // Fall back to filesystem
+        #[cfg(all(feature = "gitoxide", not(feature = "git")))]
+        {
+            let mut current = Some(_root);
+            while let Some(path) = current {
+                let git_dir = path.join(".git");
+                if git_dir.exists() {
+                    match gix::open(path) {
+                        Ok(repo) => {
+                            return Ok(Self {
+                                inner: Box::new(GitIndexPermissionsSource::new(
+                                    repo,
+                                    path.to_path_buf(),
+                                )),
+                            });
+                        }
+                        Err(_) => {}
+                    }
+                }
+                current = path.parent();
+            }
+        }
+
         Ok(Self {
             inner: Box::new(FilesystemPermissionsSource),
         })

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,6 +40,27 @@ impl HeaderWriter {
     }
 }
 
+/// Build a SWHID-format signature tuple from raw parts.
+///
+/// Used by both `git` (libgit2) and `git_gix` (gitoxide) backends.
+pub(crate) fn build_signature(
+    name: &[u8],
+    email: &[u8],
+    timestamp: i64,
+    offset: &str,
+) -> (Box<[u8]>, i64, Box<[u8]>) {
+    let mut full_name = Vec::with_capacity(name.len() + email.len() + 3);
+    full_name.extend_from_slice(name);
+    full_name.extend_from_slice(b" <");
+    full_name.extend_from_slice(email);
+    full_name.push(b'>');
+    (
+        full_name.into(),
+        timestamp,
+        offset.as_bytes().to_vec().into_boxed_slice(),
+    )
+}
+
 /// Returns `Err(item)` if the `item` is present twice in a row.
 pub(crate) fn check_unique<T: AsRef<[u8]>>(items: impl IntoIterator<Item = T>) -> Result<(), T> {
     let mut items = items.into_iter();

--- a/tests/git_gix.rs
+++ b/tests/git_gix.rs
@@ -1,0 +1,233 @@
+//! Tests for the gitoxide backend (git_gix module).
+//!
+//! Uses the git CLI for repo creation instead of git2, so this test file
+//! has no dependency on the `git` feature. Cross-validation tests that
+//! compare both backends are gated on `#[cfg(all(feature = "git", feature = "gitoxide"))]`.
+
+#![cfg(feature = "gitoxide")]
+
+use std::collections::HashMap;
+use std::process::Command;
+
+use assert_fs::prelude::*;
+use gix::ObjectId;
+
+use swhid::git_gix::*;
+
+/// Create a git repo with a single file and commit using the git CLI.
+/// Returns (gix::Repository, commit ObjectId).
+fn make_test_repo_cli(
+    tmp: &assert_fs::TempDir,
+    file_name: &str,
+    file_content: &str,
+    author_name: &str,
+    author_email: &str,
+    timestamp: i64,
+    tz_offset_str: &str,
+    message: &str,
+) -> (gix::Repository, ObjectId) {
+    let dir = tmp.path();
+
+    // git init
+    let status = Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(dir)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("HOME", dir)
+        .output()
+        .expect("git must be installed to run these tests");
+    assert!(status.status.success(), "git init failed: {:?}", status);
+
+    // Write file
+    let file_path = tmp.child(file_name);
+    file_path.write_str(file_content).unwrap();
+
+    // git add
+    let status = Command::new("git")
+        .args(["add", file_name])
+        .current_dir(dir)
+        .output()
+        .expect("git add failed");
+    assert!(status.status.success());
+
+    // git commit with controlled timestamp
+    let date_str = format!("{} {}", timestamp, tz_offset_str);
+    let status = Command::new("git")
+        .args(["commit", "-m", message])
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", author_name)
+        .env("GIT_AUTHOR_EMAIL", author_email)
+        .env("GIT_AUTHOR_DATE", &date_str)
+        .env("GIT_COMMITTER_NAME", author_name)
+        .env("GIT_COMMITTER_EMAIL", author_email)
+        .env("GIT_COMMITTER_DATE", &date_str)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("HOME", dir)
+        .output()
+        .expect("git commit failed");
+    assert!(
+        status.status.success(),
+        "git commit failed: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    // Get HEAD commit hash
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(dir)
+        .output()
+        .expect("git rev-parse failed");
+    assert!(output.status.success());
+    let hash = String::from_utf8(output.stdout).unwrap().trim().to_string();
+
+    let repo = gix::open(dir).unwrap();
+    let oid = ObjectId::from_hex(hash.as_bytes()).unwrap();
+    (repo, oid)
+}
+
+#[test]
+fn test_revision_swhid_gix() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let (repo, commit_oid) = make_test_repo_cli(
+        &tmp,
+        "test.txt",
+        "test content",
+        "Test User",
+        "test@example.com",
+        1763027354,
+        "+0100",
+        "Initial commit\n",
+    );
+
+    let swhid = revision_swhid(&repo, &commit_oid, &mut HashMap::new()).unwrap();
+    assert_eq!(swhid.object_type().as_tag(), "rev");
+    let s = swhid.to_string();
+    assert!(s.starts_with("swh:1:rev:"));
+    assert_eq!(s.len(), "swh:1:rev:".len() + 40);
+}
+
+#[test]
+fn test_snapshot_swhid_gix() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let (repo, _) = make_test_repo_cli(
+        &tmp,
+        "hello.txt",
+        "hello world",
+        "Test User",
+        "test@example.com",
+        1763027354,
+        "+0100",
+        "Initial commit\n",
+    );
+
+    let swhid = snapshot_swhid(&repo).unwrap();
+    let s = swhid.to_string();
+    assert!(s.starts_with("swh:1:snp:"));
+    assert_eq!(s.len(), "swh:1:snp:".len() + 40);
+}
+
+#[test]
+fn test_open_repo_gix() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    // Init with git CLI
+    let status = Command::new("git")
+        .args(["init"])
+        .current_dir(tmp.path())
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env("HOME", tmp.path())
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+
+    let repo = open_repo(tmp.path());
+    assert!(repo.is_ok());
+}
+
+#[test]
+fn test_open_repo_gix_invalid() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let repo = open_repo(tmp.path());
+    assert!(repo.is_err());
+}
+
+#[test]
+fn test_get_head_commit_gix() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let (repo, expected_oid) = make_test_repo_cli(
+        &tmp,
+        "test.txt",
+        "content",
+        "Test User",
+        "test@example.com",
+        1763027354,
+        "+0100",
+        "Initial commit\n",
+    );
+
+    let head_oid = get_head_commit(&repo).unwrap();
+    assert_eq!(head_oid, expected_oid);
+}
+
+/// Cross-validate: both backends produce the same revision SWHID.
+#[test]
+#[cfg(feature = "git")]
+fn test_revision_matches_git2_backend() {
+    use swhid::git as git2_mod;
+
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let (repo_gix, commit_oid_gix) = make_test_repo_cli(
+        &tmp,
+        "cross.txt",
+        "cross-validation content",
+        "Cross User",
+        "cross@example.com",
+        1700000000,
+        "+0000",
+        "cross test\n",
+    );
+
+    // Compute with gitoxide backend
+    let swhid_gix = revision_swhid(&repo_gix, &commit_oid_gix, &mut HashMap::new()).unwrap();
+
+    // Compute with git2 backend
+    let repo_g2 = git2::Repository::open(tmp.path()).unwrap();
+    let commit_oid_g2 = git2::Oid::from_str(&commit_oid_gix.to_string()).unwrap();
+    let swhid_git2 =
+        git2_mod::revision_swhid(&repo_g2, &commit_oid_g2, &mut HashMap::new()).unwrap();
+
+    assert_eq!(
+        swhid_git2.to_string(),
+        swhid_gix.to_string(),
+        "git2 and gitoxide backends must produce identical revision SWHIDs"
+    );
+}
+
+/// Cross-validate snapshot SWHIDs between backends.
+#[test]
+#[cfg(feature = "git")]
+fn test_snapshot_matches_git2_backend() {
+    use swhid::git as git2_mod;
+
+    let tmp = assert_fs::TempDir::new().unwrap();
+    let (repo_gix, _) = make_test_repo_cli(
+        &tmp,
+        "snap.txt",
+        "snapshot content",
+        "Snap User",
+        "snap@example.com",
+        1700000000,
+        "+0000",
+        "snap commit\n",
+    );
+
+    let swhid_gix = snapshot_swhid(&repo_gix).unwrap();
+
+    let repo_g2 = git2::Repository::open(tmp.path()).unwrap();
+    let swhid_git2 = git2_mod::snapshot_swhid(&repo_g2).unwrap();
+
+    assert_eq!(
+        swhid_git2.to_string(),
+        swhid_gix.to_string(),
+        "git2 and gitoxide backends must produce identical snapshot SWHIDs"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a `gitoxide` feature flag that provides the same revision, release, and snapshot SWHID computation as the existing `git` feature, but backed by the [gix](https://github.com/GitoxideLabs/gitoxide) crate (MIT/Apache-2.0) instead of libgit2 (GPL-2.0 with linking exception).

This enables downstream projects with permissive licensing requirements to use the full SWHID specification — including revision, release, and snapshot identifiers — without introducing GPL dependencies into their binary.

## Motivation

We are building [swhid-py](https://github.com/andrewmusselman/swhid-py), Python bindings for swhid-rs, for use in [Apache Trusted Releases](https://github.com/apache/tooling-trusted-releases/issues/1154). The Apache Software Foundation requires Apache-2.0 compatible licensing for all linked dependencies. The content and directory functions work perfectly, but enabling the `git` feature for revision/release/snapshot SWHIDs would statically link GPL-2.0 code into the binary, creating licensing uncertainty.

gitoxide is a pure-Rust Git implementation licensed MIT/Apache-2.0, which is unambiguously compatible.

## What changed

### New files
- **`src/git_gix.rs`** — complete gitoxide backend exposing the same public functions as `git.rs`: `open_repo`, `revision_swhid`, `release_swhid`, `snapshot_swhid`, `get_head_commit`, `get_tags`
- **`tests/git_gix.rs`** — tests including cross-validation against the git2 backend

### Modified files
- **`Cargo.toml`** — new `gitoxide = ["dep:gix"]` feature, `gix` dependency, `git2` added as dev-dependency for cross-validation tests
- **`src/lib.rs`** — conditional `pub mod git_gix` and permission type exports
- **`src/permissions.rs`** — `GixIndexPermissionsSource` and `GixTreePermissionsSource` structs, gitoxide auto-detection in `AutoPermissionsSource`
- **`src/directory.rs`** — gitoxide match arms for `PermissionsSourceKind::GitIndex/GitTree`
- **`src/main.rs`** — gitoxide CLI handling (same `git` subcommand, backend selected by feature)
- **`README.md`** — mentions gitoxide as an alternative
- **`docs/user-guide.md`** — updated features table, examples for both backends, new testing section

### Not changed
- All existing `git` (libgit2) code paths are untouched
- No changes to the SWHID computation algorithms
- No changes to public types (`Swhid`, `Revision`, `Release`, `Snapshot`, etc.)

## How it works

The `git_gix` module mirrors the `git` module's public API but uses `gix::Repository` and `gix::ObjectId` instead of `git2::Repository` and `git2::Oid`. The SWHID hashing logic is shared — both backends call the same `hash_content`, `hash_swhid_object`, and `dir_manifest` functions. Only the Git object retrieval layer differs.

When both features are enabled, `git` (libgit2) takes priority in the CLI and auto-detection to avoid ambiguity.

## Feature matrix

| Feature | Backend | License | Rev/Rel/Snp |
|---------|---------|---------|-------------|
| (none) | — | MIT | No |
| `git` | libgit2 | GPL-2.0 w/ linking exception | Yes |
| `gitoxide` | gix | MIT/Apache-2.0 | Yes |

## Testing

```bash
# Existing tests still pass
cargo test --features git

# Gitoxide backend tests
cargo test --features gitoxide

# Cross-validation: both backends, identical output
cargo test --features "git,gitoxide"
```

The cross-validation tests (`test_revision_matches_git2_backend` and `test_snapshot_matches_git2_backend`) create a repository with git2, then compute SWHIDs with both backends and assert identical results.

### Test results

```
cargo test --features "git,gitoxide"

running 106 tests  (unit tests)        ... ok
running 22 tests   (content)           ... ok
running 18 tests   (directory)         ... ok
running 6 tests    (git — libgit2)     ... ok
running 7 tests    (git_gix — gitoxide, including 2 cross-validation) ... ok
running 1 test     (release)           ... ok
running 2 tests    (revision)          ... ok
running 4 tests    (snapshot)          ... ok

test result: ok. 186 passed; 0 failed
```

## References

- [gitoxide](https://github.com/GitoxideLabs/gitoxide) — MIT/Apache-2.0 pure-Rust Git implementation
- [Apache tooling-trusted-releases#1154](https://github.com/apache/tooling-trusted-releases/issues/1154) — SWHID adoption discussion