### PR TITLE
Implement recursive display of directory SWHIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This implementation is **fully compliant** with SWHID v1.2 and provides:
 
 **Library:** `Content::from_bytes(b"data").swhid()` -> `swh:1:cnt:<hex>`. Parse with `"swh:1:cnt:...".parse::<Swhid>()`.
 
-**CLI:** `swhid content --file README.md` · `swhid dir .` · `swhid parse "swh:1:cnt:..."` · `swhid verify PATH SWHID`
+**CLI:** `swhid content --file README.md` · `swhid dir .` · `swhid dir -R .` · `swhid parse "swh:1:cnt:..."` · `swhid verify PATH SWHID`
 
 See the [user guide](docs/user-guide.md) for full documentation.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -501,9 +501,10 @@ Computes content SWHID from file or stdin.
 #### Directory Command  
 ```bash
 swhid dir /path/to/directory
-swhid dir --exclude-suffix .tmp --exclude-suffix .log .
+swhid dir -R /path/to/directory
+swhid dir --exclude .tmp --exclude .log .
 ```
-Computes directory SWHID with optional exclusions.
+Computes a directory SWHID, or with `-R/--recursive` prints `SWHID<TAB>PATH` for the root directory and all contained files and directories.
 
 #### Parse Command
 ```bash
@@ -589,4 +590,3 @@ The architecture supports several extension points:
 5. **New CLI Commands**: Add subcommands to the CLI interface
 
 This reference implementation provides a solid foundation for understanding and extending SWHID functionality while maintaining strict compliance with the SWHID v1.2 specification.
-

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,7 +35,7 @@ With the `git` feature, use `swhid::git` to compute revision, release, and snaps
 ### Commands
 
 - **Content:** `swhid content [--file PATH]` — read from file or stdin, print SWHID.
-- **Directory:** `swhid dir PATH [options]` — compute directory SWHID (see `--help` for walk and permission options).
+- **Directory:** `swhid dir PATH [options]` — compute a directory SWHID, or with `-R/--recursive` print `SWHID<TAB>PATH` for the root directory and all contained files and directories.
 - **Parse:** `swhid parse "swh:1:cnt:..."`
 - **Verify:** `swhid verify PATH SWHID` — compute SWHID for path and compare to given SWHID.
 - **Git** (with `git` feature): `swhid git revision REPO [COMMIT]`, `swhid git release REPO TAG`, `swhid git snapshot REPO`, `swhid git tags REPO`.
@@ -118,6 +118,7 @@ echo "Hello, World!" | swhid content
 
 # Directory
 swhid dir .
+swhid dir -R .
 swhid dir --exclude .tmp --exclude .log /path/to/project
 
 # Parse and verify

--- a/src/content.rs
+++ b/src/content.rs
@@ -15,9 +15,7 @@ impl<B: AsRef<[u8]>> Content<B> {
     ///
     /// This implements SWHID v1.2 content object creation for any byte data.
     pub fn from_bytes(bytes: B) -> Self {
-        Self {
-            bytes: bytes.into(),
-        }
+        Self { bytes }
     }
 
     pub fn as_bytes(&self) -> &[u8] {

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -82,6 +82,15 @@ impl Entry {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A recursively discovered filesystem path with its SWHID.
+pub struct PathEntry {
+    /// Object path, relative to the builder root. The root directory itself is `"."`.
+    pub path: PathBuf,
+    /// SWHID of the object at this path.
+    pub swhid: Swhid,
+}
+
 impl From<ManifestEntry> for Entry {
     fn from(manifest: ManifestEntry) -> Self {
         // Convert Vec<u8> to [u8; 20] for v1 compatibility
@@ -157,19 +166,17 @@ fn symlink_mode() -> u32 {
     0o120000
 }
 
-fn read_dir(
-    path: &Path,
+fn permission_source_for(
     root: &Path,
     opts: &DirectoryBuildOptions,
-) -> Result<Vec<Entry>, crate::error::SwhidError> {
+) -> Result<Box<dyn PermissionsSource>, crate::error::SwhidError> {
     use crate::permissions::{
         AutoPermissionsSource, FilesystemPermissionsSource, ManifestPermissionsSource,
     };
     #[cfg(feature = "git")]
     use crate::permissions::{GitIndexPermissionsSource, GitTreePermissionsSource};
 
-    // Create permission source based on options
-    let permission_source: Box<dyn PermissionsSource> = match opts.permissions_source {
+    Ok(match opts.permissions_source {
         PermissionsSourceKind::Auto => Box::new(AutoPermissionsSource::new(root)?),
         PermissionsSourceKind::Filesystem => Box::new(FilesystemPermissionsSource),
         #[cfg(feature = "git")]
@@ -210,7 +217,44 @@ fn read_dir(
             // Heuristic not implemented yet, fall back to filesystem
             Box::new(FilesystemPermissionsSource)
         }
-    };
+    })
+}
+
+/// Collect SWHIDs recursively during directory traversal.
+trait SwhidCollector {
+    fn push(&mut self, path: PathBuf, swhid: Swhid);
+}
+
+#[derive(Default)]
+/// Null SWHID collector, i.e., a "collector" that throws away all SWHIDs pushed to it.
+/// Used for non-recursive SWHID display.
+struct NullSwhidCollector;
+
+impl SwhidCollector for NullSwhidCollector {
+    fn push(&mut self, _path: PathBuf, _swhid: Swhid) {}
+}
+
+impl SwhidCollector for Vec<PathEntry> {
+    fn push(&mut self, path: PathBuf, swhid: Swhid) {
+        self.push(PathEntry { path, swhid });
+    }
+}
+
+fn local_path(root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+fn build_directory(entries: Vec<Entry>) -> Result<Directory, crate::error::SwhidError> {
+    Directory::new(entries).map_err(|e| crate::error::SwhidError::Io(std::io::Error::other(e)))
+}
+
+fn read_dir_with_permission_source<C: SwhidCollector>(
+    path: &Path,
+    root: &Path,
+    opts: &DirectoryBuildOptions,
+    permission_source: &dyn PermissionsSource,
+    collector: &mut C,
+) -> Result<Vec<Entry>, crate::error::SwhidError> {
     let mut children: Vec<Entry> = Vec::new();
     for entry in fs::read_dir(path).map_err(|e| {
         crate::error::SwhidError::Io(std::io::Error::other(format!(
@@ -252,14 +296,16 @@ fn read_dir(
         let ft = md.file_type();
 
         if ft.is_dir() {
-            let nested_entries = read_dir(&entry.path(), root, opts)?;
-            let manifest = dir_manifest(nested_entries).map_err(|e: DirectoryError| {
-                crate::error::SwhidError::Io(std::io::Error::other(format!(
-                    "Failed to build directory manifest: {}",
-                    e
-                )))
-            })?;
-            let id = hash_swhid_object("tree", &manifest);
+            let nested_entries = read_dir_with_permission_source(
+                &entry.path(),
+                root,
+                opts,
+                permission_source,
+                collector,
+            )?;
+            let nested_swhid = build_directory(nested_entries)?.swhid()?;
+            let id = *nested_swhid.digest_bytes();
+            collector.push(local_path(root, &entry.path()), nested_swhid);
             children.push(Entry {
                 name: name_bytes,
                 mode: 0o040000,
@@ -276,6 +322,10 @@ fn read_dir(
             })?;
             let bytes = target.as_os_str().as_encoded_bytes();
             let id = hash_content(bytes);
+            collector.push(
+                local_path(root, &entry.path()),
+                Swhid::new(ObjectType::Content, id),
+            );
             children.push(Entry {
                 name: name_bytes,
                 mode: symlink_mode(),
@@ -290,6 +340,10 @@ fn read_dir(
                 )))
             })?;
             let id = hash_content(&bytes);
+            collector.push(
+                local_path(root, &entry.path()),
+                Swhid::new(ObjectType::Content, id),
+            );
 
             // Use permission source to determine executable bit
             let exec = permission_source.executable_of(&entry.path())?;
@@ -307,6 +361,16 @@ fn read_dir(
         }
     }
     Ok(children)
+}
+
+fn read_dir(
+    path: &Path,
+    root: &Path,
+    opts: &DirectoryBuildOptions,
+) -> Result<Vec<Entry>, crate::error::SwhidError> {
+    let permission_source = permission_source_for(root, opts)?;
+    let mut collector = NullSwhidCollector;
+    read_dir_with_permission_source(path, root, opts, permission_source.as_ref(), &mut collector)
 }
 
 /// SWHID v1.2 directory object for computing directory SWHIDs.
@@ -391,7 +455,7 @@ impl<'a> DiskDirectoryBuilder<'a> {
 
     pub fn build(self) -> Result<Directory, crate::error::SwhidError> {
         let entries = read_dir(self.root, self.root, &self.opts)?;
-        Directory::new(entries).map_err(|e| crate::error::SwhidError::Io(std::io::Error::other(e)))
+        build_directory(entries)
     }
 
     /// Compute the SWHID v1.2 directory identifier for this directory.
@@ -400,8 +464,29 @@ impl<'a> DiskDirectoryBuilder<'a> {
     /// is compatible with Git's tree format for directory objects.
     pub fn swhid(&self) -> Result<Swhid, crate::error::SwhidError> {
         let entries = read_dir(self.root, self.root, &self.opts)?;
-        Directory::new(entries)
-            .map_err(|e| crate::error::SwhidError::Io(std::io::Error::other(e)))?
-            .swhid()
+        build_directory(entries)?.swhid()
+    }
+
+    /// Compute the SWHIDs of all contained files and directories recursively.
+    ///
+    /// Returned paths are relative to the builder root. The root directory itself
+    /// is represented as `"."`.
+    pub fn recursive_swhids(&self) -> Result<Vec<PathEntry>, crate::error::SwhidError> {
+        let permission_source = permission_source_for(self.root, &self.opts)?;
+        let mut recursive_swhids = Vec::new();
+        let entries = read_dir_with_permission_source(
+            self.root,
+            self.root,
+            &self.opts,
+            permission_source.as_ref(),
+            &mut recursive_swhids,
+        )?;
+        let root_swhid = build_directory(entries)?.swhid()?;
+        recursive_swhids.push(PathEntry {
+            path: PathBuf::from("."),
+            swhid: root_swhid,
+        });
+        recursive_swhids.sort_unstable_by(|a, b| a.path.cmp(&b.path));
+        Ok(recursive_swhids)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod utils;
 
 pub use content::Content;
 pub use core::{ObjectType, Swhid};
-pub use directory::{Directory, DiskDirectoryBuilder, Entry, WalkOptions};
+pub use directory::{Directory, DiskDirectoryBuilder, Entry, PathEntry, WalkOptions};
 pub use directory::{DirectoryBuildOptions, ManifestEntry};
 pub use permissions::{
     resolve_file_permissions, EntryExec, EntryPerms, PermissionPolicy, PermissionsSource,

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,10 +31,13 @@ enum Command {
         #[arg(short, long)]
         file: Option<PathBuf>,
     },
-    /// Compute a directory SWHID recursively
+    /// Compute a directory SWHID from a filesystem tree
     Dir {
         /// Directory root
         path: PathBuf,
+        /// Output SWHIDs for all contained files and directories
+        #[arg(short = 'R', long)]
+        recursive: bool,
         /// Follow symlinks (not recommended)
         #[arg(long)]
         follow_symlinks: bool,
@@ -159,6 +162,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Dir {
             path,
+            recursive,
             follow_symlinks,
             exclude,
             permissions_source,
@@ -185,8 +189,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             let dir = DiskDirectoryBuilder::new(&path).with_build_options(build_opts);
-            let swhid = dir.swhid()?;
-            println!("{swhid}");
+            if recursive {
+                for entry in dir.recursive_swhids()? {
+                    println!("{}\t{}", entry.swhid, entry.path.display());
+                }
+            } else {
+                let swhid = dir.swhid()?;
+                println!("{swhid}");
+            }
         }
         Command::Parse { swhid } => {
             // Try qualified first, fallback to core

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+use assert_fs::prelude::*;
+
+use swhid::DiskDirectoryBuilder;
+
+#[test]
+fn dir_recursive_prints_local_paths_and_swhids() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    tmp.child("a.txt").write_str("A").unwrap();
+    tmp.child("subdir").create_dir_all().unwrap();
+    tmp.child("subdir/b.txt").write_str("B").unwrap();
+
+    let expected = DiskDirectoryBuilder::new(tmp.path())
+        .recursive_swhids()
+        .unwrap()
+        .into_iter()
+        .map(|entry| format!("{}\t{}", entry.swhid, entry.path.display()))
+        .collect::<Vec<_>>()
+        .join("\n")
+        + "\n";
+
+    let output = Command::new(env!("CARGO_BIN_EXE_swhid"))
+        .args(["dir", "-R"])
+        .arg(tmp.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+}

--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -2,6 +2,7 @@ use assert_fs::prelude::*;
 
 use swhid::directory::*;
 use swhid::hash::hash_content;
+use swhid::Content;
 use swhid::ObjectType;
 
 fn name(s: &'static str) -> Box<[u8]> {
@@ -181,6 +182,45 @@ fn read_nested_dir_structure() {
     let dir = DiskDirectoryBuilder::new(tmp.path());
     let id = dir.swhid().unwrap();
     assert_eq!(id.object_type(), ObjectType::Directory);
+}
+
+#[test]
+fn rec_dir_swhids() {
+    let tmp = assert_fs::TempDir::new().unwrap();
+    tmp.child("a.txt").write_str("A").unwrap();
+    tmp.child("subdir").create_dir_all().unwrap();
+    tmp.child("subdir/b.txt").write_str("B").unwrap();
+
+    let root_swhid = DiskDirectoryBuilder::new(tmp.path()).swhid().unwrap();
+    let subdir_swhid = DiskDirectoryBuilder::new(&tmp.path().join("subdir"))
+        .swhid()
+        .unwrap();
+
+    let entries = DiskDirectoryBuilder::new(tmp.path())
+        .recursive_swhids()
+        .unwrap();
+
+    assert_eq!(
+        entries,
+        vec![
+            PathEntry {
+                path: ".".into(),
+                swhid: root_swhid,
+            },
+            PathEntry {
+                path: "a.txt".into(),
+                swhid: Content::from_bytes(b"A").swhid(),
+            },
+            PathEntry {
+                path: "subdir".into(),
+                swhid: subdir_swhid,
+            },
+            PathEntry {
+                path: "subdir/b.txt".into(),
+                swhid: Content::from_bytes(b"B").swhid(),
+            },
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR implements recursive display of directory SWHIDs.

It is based on an initial implementation by Copilot:GPT-5.4, which I've subsequently reviewed and reworked.

The implementation is pretty fast, being only marginally slower than non-recursive display (the slowdown is probably just printing time, hence incompressible further, but I have not verified that):
```
$ hyperfine "cargo r --release -- dir /srv/src/linux/linux-5.9.1/" "cargo r --release -- dir -R /srv/src/linux/linux-5.9.1/"  
Benchmark 1: cargo r --release -- dir /srv/src/linux/linux-5.9.1/
  Time (mean ± σ):     19.483 s ±  0.110 s    [User: 17.526 s, System: 1.953 s]
  Range (min … max):   19.368 s … 19.742 s    10 runs
 
Benchmark 2: cargo r --release -- dir -R /srv/src/linux/linux-5.9.1/
  Time (mean ± σ):     20.036 s ±  0.178 s    [User: 17.998 s, System: 2.034 s]
  Range (min … max):   19.881 s … 20.503 s    10 runs
 
Summary
  cargo r --release -- dir /srv/src/linux/linux-5.9.1/ ran
    1.03 ± 0.01 times faster than cargo r --release -- dir -R /srv/src/linux/linux-5.9.1/
```

Closes swhid/swhid-rs#47