### PR TITLE
feat: gate the CLI behind a default-on cli feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,3 +23,5 @@ jobs:
         run: cargo clippy
       - name: Run tests
         run: RUST_BACKTRACE=full cargo test --verbose
+      - name: Check the library without the CLI feature
+        run: cargo check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ keywords = ["swhid", "iso18670", "software-heritage", "identifier", "hash"]
 categories = ["encoding", "data-structures", "parsing"]
 
 [features]
-default = []
+# The default features carry the `swhid` CLI (what `cargo install swhid` builds); library consumers opt out with `default-features = false` and skip clap entirely.
+default = ["cli"]
+cli = ["dep:clap"]
 serde = ["dep:serde"]
 git = ["dep:git2"]
 
@@ -18,9 +20,14 @@ hex = "0.4"
 thiserror = "1"
 percent-encoding = "2"
 serde = { version = "1", features = ["derive"], optional = true }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"], optional = true }
 sha1collisiondetection = { version = "0.3" }
 git2 = { version = "0.20", optional = true }
+
+[[bin]]
+name = "swhid"
+path = "src/main.rs"
+required-features = ["cli"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ This implementation is **fully compliant** with SWHID v1.2 and provides:
 
 **Library:** `Content::from_bytes(b"data").swhid()` -> `swh:1:cnt:<hex>`. Parse with `"swh:1:cnt:...".parse::<Swhid>()`.
 
+Library consumers can skip the CLI and its clap dependency tree:
+
+```toml
+[dependencies]
+swhid = { version = "0.2", default-features = false }
+```
+
+The default features include `cli` (the `swhid` binary), which is what `cargo install swhid` builds.
+
 **CLI:** `swhid content --file README.md` · `swhid dir .` · `swhid dir -R .` · `swhid parse "swh:1:cnt:..."` · `swhid verify PATH SWHID`
 
 See the [user guide](docs/user-guide.md) for full documentation.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,6 +4,15 @@ This guide describes how to use the `swhid` library and CLI for computing and pa
 
 ## Library usage
 
+Library consumers can skip the CLI and its clap dependency tree:
+
+```toml
+[dependencies]
+swhid = { version = "0.2", default-features = false }
+```
+
+The default features include `cli` (the `swhid` binary), which is what `cargo install swhid` builds.
+
 ### SWHID v1 identifiers
 
 The library produces **SWHID v1** identifiers: SHA-1 digest, lowercase hex encoding, version `1` in the URI.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,15 +4,6 @@ This guide describes how to use the `swhid` library and CLI for computing and pa
 
 ## Library usage
 
-Library consumers can skip the CLI and its clap dependency tree:
-
-```toml
-[dependencies]
-swhid = { version = "0.2", default-features = false }
-```
-
-The default features include `cli` (the `swhid` binary), which is what `cargo install swhid` builds.
-
 ### SWHID v1 identifiers
 
 The library produces **SWHID v1** identifiers: SHA-1 digest, lowercase hex encoding, version `1` in the URI.


### PR DESCRIPTION
Closes #51 

clap 4 + derive was an unconditional dependency because the `swhid` binary lives in the library package; every library consumer built the clap/syn/quote tree to parse identifiers.

- `default = ["cli"]`, `cli = ["dep:clap"]`, and an explicit `[[bin]]` with `required-features = ["cli"]` — `cargo install swhid`, the release binaries, and every default-features consumer behave exactly as before.
- `default-features = false` now yields the library alone: `cargo tree --no-default-features -e normal` carries no clap (the remaining proc-macro tree is thiserror's derive, unchanged by this PR).
- The user guide's library section shows the lean dependency line; the CI pipeline gains one `cargo check --no-default-features` step so the gate cannot regress.
