### PR TITLE
Add read accessors for QualifiedSwhid qualifier fields

### DIFF
--- a/src/qualifier.rs
+++ b/src/qualifier.rs
@@ -118,6 +118,36 @@ impl QualifiedSwhid {
         &self.core
     }
 
+    /// The `origin` qualifier, percent-decoded.
+    pub fn origin(&self) -> Option<&str> {
+        self.origin.as_deref()
+    }
+    /// The `visit` qualifier.
+    pub fn visit(&self) -> Option<&Swhid> {
+        self.visit.as_ref()
+    }
+    /// The `anchor` qualifier.
+    pub fn anchor(&self) -> Option<&Swhid> {
+        self.anchor.as_ref()
+    }
+    /// The `path` qualifier, percent-decoded.
+    pub fn path(&self) -> Option<&str> {
+        self.path.as_deref()
+    }
+    /// The `lines` qualifier.
+    pub fn lines(&self) -> Option<&LineRange> {
+        self.lines.as_ref()
+    }
+    /// The `bytes` qualifier.
+    pub fn bytes(&self) -> Option<&ByteRange> {
+        self.bytes.as_ref()
+    }
+    /// Qualifiers whose keys are not known to this implementation, in the
+    /// order they were parsed or pushed.
+    pub fn others(&self) -> &[(String, String)] {
+        &self.others
+    }
+
     pub fn with_origin(mut self, url: impl Into<String>) -> Self {
         self.origin = Some(url.into());
         self
@@ -888,6 +918,85 @@ mod tests {
         let formatted = q.to_string();
         let parsed: QualifiedSwhid = formatted.parse().unwrap();
         assert_eq!(q, parsed);
+    }
+
+    #[test]
+    fn qualified_swhid_accessors() {
+        let s = "swh:1:cnt:b45ef6fec89518d314f546fd6c3025367b721684\
+                 ;origin=https://example.org/repo.git\
+                 ;visit=swh:1:snp:123456789abcdef0112233445566778899aabbcc\
+                 ;anchor=swh:1:rev:123456789abcdef0112233445566778899aabbcc\
+                 ;path=/src/lib.rs\
+                 ;lines=10-20\
+                 ;bytes=100-200\
+                 ;custom=value";
+        let q: QualifiedSwhid = s.parse().unwrap();
+
+        assert_eq!(
+            q.core(),
+            &"swh:1:cnt:b45ef6fec89518d314f546fd6c3025367b721684"
+                .parse::<Swhid>()
+                .unwrap()
+        );
+        assert_eq!(q.origin(), Some("https://example.org/repo.git"));
+        assert_eq!(
+            q.visit(),
+            Some(
+                &"swh:1:snp:123456789abcdef0112233445566778899aabbcc"
+                    .parse::<Swhid>()
+                    .unwrap()
+            )
+        );
+        assert_eq!(
+            q.anchor(),
+            Some(
+                &"swh:1:rev:123456789abcdef0112233445566778899aabbcc"
+                    .parse::<Swhid>()
+                    .unwrap()
+            )
+        );
+        assert_eq!(q.path(), Some("/src/lib.rs"));
+        assert_eq!(
+            q.lines(),
+            Some(&LineRange {
+                start: 10,
+                end: Some(20)
+            })
+        );
+        assert_eq!(
+            q.bytes(),
+            Some(&ByteRange {
+                start: 100,
+                end: Some(200)
+            })
+        );
+        assert_eq!(q.others(), [("custom".to_string(), "value".to_string())]);
+    }
+
+    #[test]
+    fn qualified_swhid_accessors_percent_decode() {
+        let s = "swh:1:cnt:b45ef6fec89518d314f546fd6c3025367b721684\
+                 ;origin=https://example.org/repo.git?foo=bar%3Bbaz\
+                 ;path=/this%3Bis%C2%A0a/file";
+        let q: QualifiedSwhid = s.parse().unwrap();
+
+        assert_eq!(q.origin(), Some("https://example.org/repo.git?foo=bar;baz"));
+        assert_eq!(q.path(), Some("/this;is\u{00A0}a/file"));
+    }
+
+    #[test]
+    fn qualified_swhid_accessors_bare_core() {
+        let s = "swh:1:cnt:b45ef6fec89518d314f546fd6c3025367b721684";
+        let q: QualifiedSwhid = s.parse().unwrap();
+
+        assert_eq!(q.core().to_string(), s);
+        assert_eq!(q.origin(), None);
+        assert_eq!(q.visit(), None);
+        assert_eq!(q.anchor(), None);
+        assert_eq!(q.path(), None);
+        assert_eq!(q.lines(), None);
+        assert_eq!(q.bytes(), None);
+        assert!(q.others().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
tl;dr: I'm currently doing my own regex parsing of qualifier fields because they don't seem to be exposed by this crate's API (although they are parsed internally)

---

longer version (c/o Claude):

## Motivation

`QualifiedSwhid` already does the hard part: `FromStr` parses and validates every qualifier — percent-decoding `origin` and `path`, parsing `visit`/`anchor` as full `Swhid`s, range-checking `lines`/`bytes`, and preserving unknown keys. But all of that lands in private fields, and the only getter is `core()`. Serde does not offer a way around it either: `Serialize` emits the opaque display string.

So downstream consumers validate with this crate and then re-parse the same string themselves. A concrete example from [git-prov](https://github.com/gabrielgrant/git-prov), `src/lib.rs` in `parse_swhid`:

```rust
// The reference implementation validates conformance (grammar, hex
// digests, qualifier encoding)...
value.parse::<QualifiedSwhid>().ok()?;
// ...but its 0.2.x QualifiedSwhid keeps qualifier fields private, so
// extraction still happens here, against the canonical emission order
// (anchor, path, bytes) that we and the crate's Display both produce.
// Swap this for accessor calls when the crate grows them.
let re = Regex::new(
    r"^swh:1:cnt:([0-9a-f]{40});anchor=swh:1:rev:([0-9a-f]{40});path=([^;]+?)(?:;bytes=([0-9]+)-([0-9]+))?$",
).expect("valid swhid regex");
```

That hand-rolled regex duplicates work the crate has already done correctly, and it is fragile in exactly the ways the crate is not — it hardcodes qualifier order, redoes percent-decoding, and silently fails to match anything the crate would happily accept.

## Change

Purely-additive getters on `QualifiedSwhid`, mirroring the existing `core()`:

```rust
pub fn origin(&self) -> Option<&str>
pub fn visit(&self) -> Option<&Swhid>
pub fn anchor(&self) -> Option<&Swhid>
pub fn path(&self) -> Option<&str>
pub fn lines(&self) -> Option<&LineRange>
pub fn bytes(&self) -> Option<&ByteRange>
pub fn others(&self) -> &[(String, String)]
```

`origin()` and `path()` return the percent-decoded values, matching what `FromStr` stored and what the `with_*` builders take. `others()` yields unknown qualifiers in parse order, so round-trip-preserving consumers can inspect them.

No signature or behaviour changes to anything existing — this is semver-minor. There is no `Cargo.toml` version bump here and no changelog in the repo to update; happy to add either if you would prefer.

## Tests

Three tests added in `qualifier.rs`, following the existing style there:

- `qualified_swhid_accessors` — parses a string exercising every qualifier (`origin`, `visit`, `anchor`, `path`, `lines`, `bytes`, plus an unknown key) and asserts each getter.
- `qualified_swhid_accessors_percent_decode` — asserts `origin()`/`path()` return decoded values, covering the escaping behaviour from #3.
- `qualified_swhid_accessors_bare_core` — asserts `None`/empty on a bare-core `QualifiedSwhid`.

`cargo fmt --check`, `cargo clippy --all-targets --all-features`, and `cargo test` are clean (clippy warning count unchanged from `main`; the remaining warnings are pre-existing in `tests/directory.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)